### PR TITLE
feat(renovate): don't suggest Go dependency bumps that update `go` directive

### DIFF
--- a/default.json
+++ b/default.json
@@ -17,6 +17,13 @@
         "digest"
       ],
       "changelogUrl": "{{sourceUrl}}/compare/{{currentDigest}}..{{newDigest}}"
+    },
+    {
+      "description": "Ensure that dependency updates do not bump the `go` directive, and only suggests updates that stay within the `go` directive (allowing a patch bump at most)",
+      "matchManagers": [
+        "gomod"
+      ],
+      "constraintFiltering": "strict"
     }
   ],
   "regexManagers": [


### PR DESCRIPTION
This will reduce the PRs we get raised, allowing us to more easily
review Go module update PRs, as they won't break our `go` directive
constraints.
