### PR TITLE
chore(renovate): always use semantic commits

### DIFF
--- a/default.json
+++ b/default.json
@@ -41,5 +41,6 @@
   "postUpdateOptions": [
     "gomodTidy",
     "gomodUpdateImportPaths"
-  ]
+  ],
+  "semanticCommits": "enabled"
 }


### PR DESCRIPTION
Instead of detecting it and sometimes it changing depending on merged PR
titles.
