### PR TITLE
feat: add a user-facing Renovate config

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,16 @@ This repository contains [Shareable Config Presets](https://docs.renovatebot.com
 
 ## `user.json`
 
-For use by `oapi-codegen` users.
+For use by `oapi-codegen` users, and can be used like so:
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>oapi-codegen/renovate-config:user"
+  ]
+}
+```
 
 Provides utilities to:
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # Renovate configuration for oapi-codegen
+
+This repository contains [Shareable Config Presets](https://docs.renovatebot.com/config-presets/) for [Renovate](https://docs.renovatebot.com/) usage across [`oapi-codegen`](https://github.com/oapi-codegen/oapi-codegen) and its related projects.
+
+## `default.json`
+
+This configuration is used across all repositories in the `oapi-codegen` org.

--- a/README.md
+++ b/README.md
@@ -2,13 +2,6 @@
 
 This repository contains [Shareable Config Presets](https://docs.renovatebot.com/config-presets/) for [Renovate](https://docs.renovatebot.com/) usage across [`oapi-codegen`](https://github.com/oapi-codegen/oapi-codegen) and its related projects.
 
-## `default.json`
-
-> [!NOTE]
-> It is not intended for usage outside of `oapi-codegen`.
-
-This configuration is used across all repositories in the `oapi-codegen` org.
-
 ## `user.json`
 
 For use by `oapi-codegen` users.
@@ -16,3 +9,10 @@ For use by `oapi-codegen` users.
 Provides utilities to:
 
 - Keep JSON schema references (in `yaml-language-server` comments) updated alongside the version of `oapi-codegen`
+
+## `default.json`
+
+> [!NOTE]
+> It is not intended for usage outside of `oapi-codegen`.
+
+This configuration is used across all repositories in the `oapi-codegen` org.

--- a/README.md
+++ b/README.md
@@ -4,4 +4,15 @@ This repository contains [Shareable Config Presets](https://docs.renovatebot.com
 
 ## `default.json`
 
+> [!NOTE]
+> It is not intended for usage outside of `oapi-codegen`.
+
 This configuration is used across all repositories in the `oapi-codegen` org.
+
+## `user.json`
+
+For use by `oapi-codegen` users.
+
+Provides utilities to:
+
+- Keep JSON schema references (in `yaml-language-server` comments) updated alongside the version of `oapi-codegen`

--- a/user.json
+++ b/user.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Configuration to improve updates for `oapi-codegen` users",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "**/*.yaml",
+        "**/*.yml"
+      ],
+      "matchStrings": [
+        "# yaml-language-server: \\$schema=https://raw.githubusercontent.com/oapi-codegen/oapi-codegen/(?<currentValue>[^/]+)/configuration-schema.json"
+      ],
+      "depNameTemplate": "github.com/oapi-codegen/oapi-codegen/v2",
+      "datasourceTemplate": "go"
+    }
+  ]
+}


### PR DESCRIPTION
Via [0], we can make this a shared preset others can use.

[0]: https://www.jvt.me/posts/2026/03/01/oapi-codegen-config-renovate/