### PR TITLE
chore: use `user` preset across projects

### DIFF
--- a/default.json
+++ b/default.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:best-practices",
-    "helpers:pinGitHubActionDigestsToSemver"
+    "helpers:pinGitHubActionDigestsToSemver",
+    "github>oapi-codegen/renovate-config:user"
   ],
   "labels": [
     "dependencies"


### PR DESCRIPTION
As a way to "drink our own champagne" as well as getting the benefit of
the usage across our repos.
